### PR TITLE
Require "rmagick" instead of "RMagick".

### DIFF
--- a/lib/timelapsify/rmagick_screenshot_capturer.rb
+++ b/lib/timelapsify/rmagick_screenshot_capturer.rb
@@ -1,5 +1,5 @@
 require "date"
-require "RMagick"
+require "rmagick"
 
 module Timelapsify
 	class RMagickScreenshotCapturer


### PR DESCRIPTION
This PR is in response to #5.